### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/R/Data.R
+++ b/R/Data.R
@@ -116,7 +116,7 @@
 #' Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 #' Modeling. Boston: Birkhuser Boston, pp. 21-33.
 #'
-#' Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2}.
+#' Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2}.
 #'
 "Course_data"
 

--- a/R/GHGbeta.R
+++ b/R/GHGbeta.R
@@ -51,7 +51,7 @@
 #' Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 #' of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 #'
-#' Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}
+#' Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}
 #'
 #' Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 #'
@@ -206,7 +206,7 @@
 #' Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 #' of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 #'
-#' Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}
+#' Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}
 #'
 #' Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 #'
@@ -363,7 +363,7 @@ pGHGBeta<-function(p,n,a,b,c)
 #' Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 #' of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 #'
-#' Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}
+#' Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}
 #'
 #' Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 #'
@@ -530,7 +530,7 @@ mazGHGBeta<-function(r,n,a,b,c)
 #' Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 #' of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 #'
-#' Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}.
+#' Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}.
 #'
 #' Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 #'
@@ -677,7 +677,7 @@ dGHGBB<-function(x,n,a,b,c)
 #' Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 #' of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 #'
-#' Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}
+#' Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}
 #'
 #' Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 #'
@@ -758,7 +758,7 @@ pGHGBB<-function(x,n,a,b,c)
 #' Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 #' of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 #'
-#' Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}
+#' Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}
 #'
 #' Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 #'
@@ -852,7 +852,7 @@ NegLLGHGBB<-function(x,freq,a,b,c)
 #' Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 #' of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 #'
-#' Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}
+#' Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}
 #'
 #' Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 #'
@@ -949,7 +949,7 @@ EstMLEGHGBB<-function(x,freq,a,b,c)
 #' Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 #' of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 #'
-#' Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}
+#' Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}
 #'
 #' Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 #'

--- a/R/Kumaraswamy.R
+++ b/R/Kumaraswamy.R
@@ -45,12 +45,12 @@
 #' Kumaraswamy, P. (1980). A generalized probability density function for double-bounded random processes.
 #' Journal of Hydrology, 46(1), 79-88.
 #'
-#' Available at : \url{http://dx.doi.org/10.1016/0022-1694(80)90036-0}.
+#' Available at : \url{https://doi.org/10.1016/0022-1694(80)90036-0}.
 #'
 #' Jones, M. C. (2009). Kumaraswamy's distribution: A beta-type distribution with some tractability advantages.
 #' Statistical Methodology, 6(1), 70-81.
 #'
-#' Available at : \url{http://dx.doi.org/10.1016/j.stamet.2008.04.001}.
+#' Available at : \url{https://doi.org/10.1016/j.stamet.2008.04.001}.
 #'
 #' @seealso
 #' \code{\link[extraDistr]{Kumaraswamy}}
@@ -170,12 +170,12 @@ dKUM<-function(p,a,b)
 #' Kumaraswamy, P. (1980). A generalized probability density function for double-bounded random processes.
 #' Journal of Hydrology, 46(1), 79-88.
 #'
-#' Available at : \url{http://dx.doi.org/10.1016/0022-1694(80)90036-0}.
+#' Available at : \url{https://doi.org/10.1016/0022-1694(80)90036-0}.
 #'
 #' Jones, M. C. (2009). Kumaraswamy's distribution: A beta-type distribution with some tractability advantages.
 #' Statistical Methodology, 6(1), 70-81.
 #'
-#' Available at : \url{http://dx.doi.org/10.1016/j.stamet.2008.04.001}.
+#' Available at : \url{https://doi.org/10.1016/j.stamet.2008.04.001}.
 #'
 #' @seealso
 #' \code{\link[extraDistr]{Kumaraswamy}}
@@ -292,12 +292,12 @@ pKUM<-function(p,a,b)
 #' Kumaraswamy, P. (1980). A generalized probability density function for double-bounded random processes.
 #' Journal of Hydrology, 46(1), 79-88.
 #'
-#' Available at : \url{http://dx.doi.org/10.1016/0022-1694(80)90036-0}.
+#' Available at : \url{https://doi.org/10.1016/0022-1694(80)90036-0}.
 #'
 #' Jones, M. C. (2009). Kumaraswamy's distribution: A beta-type distribution with some tractability advantages.
 #' Statistical Methodology, 6(1), 70-81.
 #'
-#' Available at : \url{http://dx.doi.org/10.1016/j.stamet.2008.04.001}.
+#' Available at : \url{https://doi.org/10.1016/j.stamet.2008.04.001}.
 #'
 #' @seealso
 #' \code{\link[extraDistr]{Kumaraswamy}}

--- a/R/Triangle.R
+++ b/R/Triangle.R
@@ -52,7 +52,7 @@
 #' Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 #' Modeling. Boston: Birkhuser Boston, pp. 21-33.
 #'
-#' Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2} .
+#' Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2} .
 #'
 #' Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 #' Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics
@@ -195,7 +195,7 @@ dTRI<-function(p,mode)
 #' Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 #' Modeling. Boston: Birkhuser Boston, pp. 21-33.
 #'
-#' Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2} .
+#' Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2} .
 #'
 #' Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 #' Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics
@@ -333,7 +333,7 @@ pTRI<-function(p,mode)
 #' Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 #' Modeling. Boston: Birkhuser Boston, pp. 21-33.
 #'
-#' Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2}.
+#' Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2}.
 #'
 #' Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 #' Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics
@@ -476,7 +476,7 @@ mazTRI<-function(r,mode)
 #' Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 #' Modeling. Boston: Birkhuser Boston, pp. 21-33.
 #'
-#' Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2} .
+#' Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2} .
 #'
 #' Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 #' Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics
@@ -634,7 +634,7 @@ dTriBin<-function(x,n,mode)
 #' Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 #' Modeling. Boston: Birkhuser Boston, pp. 21-33.
 #'
-#' Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2}.
+#' Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2}.
 #'
 #' Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 #' Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics
@@ -717,7 +717,7 @@ pTriBin<-function(x,n,mode)
 #' Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 #' Modeling. Boston: Birkhuser Boston, pp. 21-33.
 #'
-#' Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2}.
+#' Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2}.
 #'
 #' Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 #' Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics
@@ -848,7 +848,7 @@ NegLLTriBin<-function(x,freq,mode)
 #' Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 #' Modeling. Boston: Birkhuser Boston, pp. 21-33.
 #'
-#' Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2}.
+#' Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2}.
 #'
 #' Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 #' Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics
@@ -1044,7 +1044,7 @@ coef.mlTRI<-function(object,...)
 #' Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 #' Modeling. Boston: Birkhuser Boston, pp. 21-33.
 #'
-#' Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2}.
+#' Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2}.
 #'
 #' Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 #' Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics

--- a/docs/reference/Course_data.html
+++ b/docs/reference/Course_data.html
@@ -196,7 +196,7 @@ examinations (including resits) were recorded.</p>
     <p>Extracted from</p>
 <p>Karlis, D. &amp; Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.</p>
-<p>Available at: <a href='http://dx.doi.org/10.1007/978-0-8176-4626-4_2'>http://dx.doi.org/10.1007/978-0-8176-4626-4_2</a>.</p>
+<p>Available at: <a href='https://doi.org/10.1007/978-0-8176-4626-4_2'>https://doi.org/10.1007/978-0-8176-4626-4_2</a>.</p>
     
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>

--- a/docs/reference/EstMLEGHGBB.html
+++ b/docs/reference/EstMLEGHGBB.html
@@ -227,7 +227,7 @@ error messages will be provided to go further.</p>
 
     <p>Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., &amp; Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.</p>
-<p>Available at : <a href='http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x'>http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x</a></p>
+<p>Available at : <a href='https://doi.org/10.1111/j.1467-9876.2007.00564.x'>https://doi.org/10.1111/j.1467-9876.2007.00564.x</a></p>
 <p>Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.</p>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>

--- a/docs/reference/EstMLETriBin.html
+++ b/docs/reference/EstMLETriBin.html
@@ -220,7 +220,7 @@ $$freq \ge 0$$</p>
 Series A, 120:148-191.</p>
 <p>Karlis, D. &amp; Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.</p>
-<p>Available at: <a href='http://dx.doi.org/10.1007/978-0-8176-4626-4_2'>http://dx.doi.org/10.1007/978-0-8176-4626-4_2</a>.</p>
+<p>Available at: <a href='https://doi.org/10.1007/978-0-8176-4626-4_2'>https://doi.org/10.1007/978-0-8176-4626-4_2</a>.</p>
 <p>Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics
 &amp; Computer Science, 4(24), pp.3497-3507.</p>

--- a/docs/reference/NegLLGHGBB.html
+++ b/docs/reference/NegLLGHGBB.html
@@ -221,7 +221,7 @@ error messages will be provided to go further.</p>
 
     <p>Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., &amp; Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.</p>
-<p>Available at : <a href='http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x'>http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x</a></p>
+<p>Available at : <a href='https://doi.org/10.1111/j.1467-9876.2007.00564.x'>https://doi.org/10.1111/j.1467-9876.2007.00564.x</a></p>
 <p>Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.</p>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>

--- a/docs/reference/NegLLTriBin.html
+++ b/docs/reference/NegLLTriBin.html
@@ -215,7 +215,7 @@ $$freq \ge 0$$</p>
 Series A, 120:148-191.</p>
 <p>Karlis, D. &amp; Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.</p>
-<p>Available at: <a href='http://dx.doi.org/10.1007/978-0-8176-4626-4_2'>http://dx.doi.org/10.1007/978-0-8176-4626-4_2</a>.</p>
+<p>Available at: <a href='https://doi.org/10.1007/978-0-8176-4626-4_2'>https://doi.org/10.1007/978-0-8176-4626-4_2</a>.</p>
 <p>Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics
 &amp; Computer Science, 4(24), pp.3497-3507.</p>

--- a/docs/reference/dGHGBB.html
+++ b/docs/reference/dGHGBB.html
@@ -240,7 +240,7 @@ messages will be provided to go further.</p>
 
     <p>Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., &amp; Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.</p>
-<p>Available at : <a href='http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x'>http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x</a>.</p>
+<p>Available at : <a href='https://doi.org/10.1111/j.1467-9876.2007.00564.x'>https://doi.org/10.1111/j.1467-9876.2007.00564.x</a>.</p>
 <p>Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.</p>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>

--- a/docs/reference/dGHGBeta.html
+++ b/docs/reference/dGHGBeta.html
@@ -239,7 +239,7 @@ necessary error messages will be provided to go further.</p>
 
     <p>Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., &amp; Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.</p>
-<p>Available at : <a href='http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x'>http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x</a></p>
+<p>Available at : <a href='https://doi.org/10.1111/j.1467-9876.2007.00564.x'>https://doi.org/10.1111/j.1467-9876.2007.00564.x</a></p>
 <p>Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.</p>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>

--- a/docs/reference/dKUM.html
+++ b/docs/reference/dKUM.html
@@ -227,10 +227,10 @@ necessary error messages will be provided to go further.</p>
 
     <p>Kumaraswamy, P. (1980). A generalized probability density function for double-bounded random processes.
 Journal of Hydrology, 46(1), 79-88.</p>
-<p>Available at : <a href='http://dx.doi.org/10.1016/0022-1694(80)90036-0'>http://dx.doi.org/10.1016/0022-1694(80)90036-0</a>.</p>
+<p>Available at : <a href='https://doi.org/10.1016/0022-1694(80)90036-0'>https://doi.org/10.1016/0022-1694(80)90036-0</a>.</p>
 <p>Jones, M. C. (2009). Kumaraswamy's distribution: A beta-type distribution with some tractability advantages.
 Statistical Methodology, 6(1), 70-81.</p>
-<p>Available at : <a href='http://dx.doi.org/10.1016/j.stamet.2008.04.001'>http://dx.doi.org/10.1016/j.stamet.2008.04.001</a>.</p>
+<p>Available at : <a href='https://doi.org/10.1016/j.stamet.2008.04.001'>https://doi.org/10.1016/j.stamet.2008.04.001</a>.</p>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
 

--- a/docs/reference/dTRI.html
+++ b/docs/reference/dTRI.html
@@ -230,7 +230,7 @@ Series A, 120:148-191.</p>
 Wiley Series in Probability and Mathematical Statistics, Wiley.</p>
 <p>Karlis, D. &amp; Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.</p>
-<p>Available at: <a href='http://dx.doi.org/10.1007/978-0-8176-4626-4_2'>http://dx.doi.org/10.1007/978-0-8176-4626-4_2</a> .</p>
+<p>Available at: <a href='https://doi.org/10.1007/978-0-8176-4626-4_2'>https://doi.org/10.1007/978-0-8176-4626-4_2</a> .</p>
 <p>Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics
 &amp; Computer Science, 4(24), pp.3497-3507.</p>

--- a/docs/reference/dTriBin.html
+++ b/docs/reference/dTriBin.html
@@ -230,7 +230,7 @@ necessary error messages will be provided to go further.</p>
 Series A, 120:148-191.</p>
 <p>Karlis, D. &amp; Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.</p>
-<p>Available at: <a href='http://dx.doi.org/10.1007/978-0-8176-4626-4_2'>http://dx.doi.org/10.1007/978-0-8176-4626-4_2</a> .</p>
+<p>Available at: <a href='https://doi.org/10.1007/978-0-8176-4626-4_2'>https://doi.org/10.1007/978-0-8176-4626-4_2</a> .</p>
 <p>Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics
 &amp; Computer Science, 4(24), pp.3497-3507.</p>

--- a/docs/reference/fitGHGBB.html
+++ b/docs/reference/fitGHGBB.html
@@ -244,7 +244,7 @@ error messages will be provided to go further.</p>
 
     <p>Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., &amp; Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.</p>
-<p>Available at : <a href='http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x'>http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x</a></p>
+<p>Available at : <a href='https://doi.org/10.1111/j.1467-9876.2007.00564.x'>https://doi.org/10.1111/j.1467-9876.2007.00564.x</a></p>
 <p>Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.</p>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>

--- a/docs/reference/fitTriBin.html
+++ b/docs/reference/fitTriBin.html
@@ -237,7 +237,7 @@ necessary error messages will be provided to go further.</p>
 Series A, 120:148-191.</p>
 <p>Karlis, D. &amp; Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.</p>
-<p>Available at: <a href='http://dx.doi.org/10.1007/978-0-8176-4626-4_2'>http://dx.doi.org/10.1007/978-0-8176-4626-4_2</a>.</p>
+<p>Available at: <a href='https://doi.org/10.1007/978-0-8176-4626-4_2'>https://doi.org/10.1007/978-0-8176-4626-4_2</a>.</p>
 <p>Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics
 &amp; Computer Science, 4(24), pp.3497-3507.</p>

--- a/docs/reference/mazGHGBeta.html
+++ b/docs/reference/mazGHGBeta.html
@@ -236,7 +236,7 @@ necessary error messages will be provided to go further.</p>
 
     <p>Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., &amp; Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.</p>
-<p>Available at : <a href='http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x'>http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x</a></p>
+<p>Available at : <a href='https://doi.org/10.1111/j.1467-9876.2007.00564.x'>https://doi.org/10.1111/j.1467-9876.2007.00564.x</a></p>
 <p>Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.</p>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>

--- a/docs/reference/mazKUM.html
+++ b/docs/reference/mazKUM.html
@@ -224,10 +224,10 @@ necessary error messages will be provided to go further.</p>
 
     <p>Kumaraswamy, P. (1980). A generalized probability density function for double-bounded random processes.
 Journal of Hydrology, 46(1), 79-88.</p>
-<p>Available at : <a href='http://dx.doi.org/10.1016/0022-1694(80)90036-0'>http://dx.doi.org/10.1016/0022-1694(80)90036-0</a>.</p>
+<p>Available at : <a href='https://doi.org/10.1016/0022-1694(80)90036-0'>https://doi.org/10.1016/0022-1694(80)90036-0</a>.</p>
 <p>Jones, M. C. (2009). Kumaraswamy's distribution: A beta-type distribution with some tractability advantages.
 Statistical Methodology, 6(1), 70-81.</p>
-<p>Available at : <a href='http://dx.doi.org/10.1016/j.stamet.2008.04.001'>http://dx.doi.org/10.1016/j.stamet.2008.04.001</a>.</p>
+<p>Available at : <a href='https://doi.org/10.1016/j.stamet.2008.04.001'>https://doi.org/10.1016/j.stamet.2008.04.001</a>.</p>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
 

--- a/docs/reference/mazTRI.html
+++ b/docs/reference/mazTRI.html
@@ -227,7 +227,7 @@ Series A, 120:148-191.</p>
 Wiley Series in Probability and Mathematical Statistics, Wiley.</p>
 <p>Karlis, D. &amp; Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.</p>
-<p>Available at: <a href='http://dx.doi.org/10.1007/978-0-8176-4626-4_2'>http://dx.doi.org/10.1007/978-0-8176-4626-4_2</a>.</p>
+<p>Available at: <a href='https://doi.org/10.1007/978-0-8176-4626-4_2'>https://doi.org/10.1007/978-0-8176-4626-4_2</a>.</p>
 <p>Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics
 &amp; Computer Science, 4(24), pp.3497-3507.</p>

--- a/docs/reference/pGHGBB.html
+++ b/docs/reference/pGHGBB.html
@@ -235,7 +235,7 @@ messages will be provided to go further.</p>
 
     <p>Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., &amp; Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.</p>
-<p>Available at : <a href='http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x'>http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x</a></p>
+<p>Available at : <a href='https://doi.org/10.1111/j.1467-9876.2007.00564.x'>https://doi.org/10.1111/j.1467-9876.2007.00564.x</a></p>
 <p>Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.</p>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>

--- a/docs/reference/pGHGBeta.html
+++ b/docs/reference/pGHGBeta.html
@@ -236,7 +236,7 @@ necessary error messages will be provided to go further.</p>
 
     <p>Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., &amp; Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.</p>
-<p>Available at : <a href='http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x'>http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x</a></p>
+<p>Available at : <a href='https://doi.org/10.1111/j.1467-9876.2007.00564.x'>https://doi.org/10.1111/j.1467-9876.2007.00564.x</a></p>
 <p>Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.</p>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>

--- a/docs/reference/pKUM.html
+++ b/docs/reference/pKUM.html
@@ -224,10 +224,10 @@ necessary error messages will be provided to go further.</p>
 
     <p>Kumaraswamy, P. (1980). A generalized probability density function for double-bounded random processes.
 Journal of Hydrology, 46(1), 79-88.</p>
-<p>Available at : <a href='http://dx.doi.org/10.1016/0022-1694(80)90036-0'>http://dx.doi.org/10.1016/0022-1694(80)90036-0</a>.</p>
+<p>Available at : <a href='https://doi.org/10.1016/0022-1694(80)90036-0'>https://doi.org/10.1016/0022-1694(80)90036-0</a>.</p>
 <p>Jones, M. C. (2009). Kumaraswamy's distribution: A beta-type distribution with some tractability advantages.
 Statistical Methodology, 6(1), 70-81.</p>
-<p>Available at : <a href='http://dx.doi.org/10.1016/j.stamet.2008.04.001'>http://dx.doi.org/10.1016/j.stamet.2008.04.001</a>.</p>
+<p>Available at : <a href='https://doi.org/10.1016/j.stamet.2008.04.001'>https://doi.org/10.1016/j.stamet.2008.04.001</a>.</p>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
 

--- a/docs/reference/pTRI.html
+++ b/docs/reference/pTRI.html
@@ -227,7 +227,7 @@ Series A, 120:148-191.</p>
 Wiley Series in Probability and Mathematical Statistics, Wiley.</p>
 <p>Karlis, D. &amp; Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.</p>
-<p>Available at: <a href='http://dx.doi.org/10.1007/978-0-8176-4626-4_2'>http://dx.doi.org/10.1007/978-0-8176-4626-4_2</a> .</p>
+<p>Available at: <a href='https://doi.org/10.1007/978-0-8176-4626-4_2'>https://doi.org/10.1007/978-0-8176-4626-4_2</a> .</p>
 <p>Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics
 &amp; Computer Science, 4(24), pp.3497-3507.</p>

--- a/docs/reference/pTriBin.html
+++ b/docs/reference/pTriBin.html
@@ -226,7 +226,7 @@ necessary error messages will be provided to go further.</p>
 Series A, 120:148-191.</p>
 <p>Karlis, D. &amp; Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.</p>
-<p>Available at: <a href='http://dx.doi.org/10.1007/978-0-8176-4626-4_2'>http://dx.doi.org/10.1007/978-0-8176-4626-4_2</a>.</p>
+<p>Available at: <a href='https://doi.org/10.1007/978-0-8176-4626-4_2'>https://doi.org/10.1007/978-0-8176-4626-4_2</a>.</p>
 <p>Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics
 &amp; Computer Science, 4(24), pp.3497-3507.</p>

--- a/man/Course_data.Rd
+++ b/man/Course_data.Rd
@@ -15,7 +15,7 @@ Extracted from
 Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.
 
-Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2}.
+Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2}.
 }
 \usage{
 Course_data

--- a/man/EstMLEGHGBB.Rd
+++ b/man/EstMLEGHGBB.Rd
@@ -50,7 +50,7 @@ bbmle::coef(parameters)   #extracting the parameters
 Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 
-Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}
+Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}
 
 Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 }

--- a/man/EstMLETriBin.Rd
+++ b/man/EstMLETriBin.Rd
@@ -61,7 +61,7 @@ Series A, 120:148-191.
 Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.
 
-Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2}.
+Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2}.
 
 Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics

--- a/man/NegLLGHGBB.Rd
+++ b/man/NegLLGHGBB.Rd
@@ -42,7 +42,7 @@ NegLLGHGBB(No.D.D,Obs.fre.1,.2,.3,1)     #acquiring the negative log likelihood 
 Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 
-Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}
+Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}
 
 Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 }

--- a/man/NegLLTriBin.Rd
+++ b/man/NegLLTriBin.Rd
@@ -42,7 +42,7 @@ Series A, 120:148-191.
 Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.
 
-Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2}.
+Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2}.
 
 Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics

--- a/man/dGHGBB.Rd
+++ b/man/dGHGBB.Rd
@@ -93,7 +93,7 @@ pGHGBB(0:7,7,1.3,0.3,1.3)     #acquiring the cumulative probability values
 Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 
-Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}.
+Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}.
 
 Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 }

--- a/man/dGHGBeta.Rd
+++ b/man/dGHGBeta.Rd
@@ -95,7 +95,7 @@ mazGHGBeta(1.9,15,5,6,1)
 Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 
-Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}
+Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}
 
 Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 }

--- a/man/dKUM.Rd
+++ b/man/dKUM.Rd
@@ -86,12 +86,12 @@ mazKUM(1.9,5.5,6)
 Kumaraswamy, P. (1980). A generalized probability density function for double-bounded random processes.
 Journal of Hydrology, 46(1), 79-88.
 
-Available at : \url{http://dx.doi.org/10.1016/0022-1694(80)90036-0}.
+Available at : \url{https://doi.org/10.1016/0022-1694(80)90036-0}.
 
 Jones, M. C. (2009). Kumaraswamy's distribution: A beta-type distribution with some tractability advantages.
 Statistical Methodology, 6(1), 70-81.
 
-Available at : \url{http://dx.doi.org/10.1016/j.stamet.2008.04.001}.
+Available at : \url{https://doi.org/10.1016/j.stamet.2008.04.001}.
 }
 \seealso{
 \code{\link[extraDistr]{Kumaraswamy}}

--- a/man/dTRI.Rd
+++ b/man/dTRI.Rd
@@ -91,7 +91,7 @@ Wiley Series in Probability and Mathematical Statistics, Wiley.
 Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.
 
-Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2} .
+Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2} .
 
 Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics

--- a/man/dTriBin.Rd
+++ b/man/dTriBin.Rd
@@ -89,7 +89,7 @@ Series A, 120:148-191.
 Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.
 
-Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2} .
+Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2} .
 
 Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics

--- a/man/fitGHGBB.Rd
+++ b/man/fitGHGBB.Rd
@@ -94,7 +94,7 @@ residuals(results)
 Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 
-Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}
+Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}
 
 Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 }

--- a/man/fitTriBin.Rd
+++ b/man/fitTriBin.Rd
@@ -83,7 +83,7 @@ Series A, 120:148-191.
 Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.
 
-Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2}.
+Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2}.
 
 Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics

--- a/man/mazGHGBeta.Rd
+++ b/man/mazGHGBeta.Rd
@@ -90,7 +90,7 @@ mazGHGBeta(1.9,15,5,6,1)
 Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 
-Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}
+Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}
 
 Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 }

--- a/man/mazKUM.Rd
+++ b/man/mazKUM.Rd
@@ -79,12 +79,12 @@ mazKUM(1.9,5.5,6)
 Kumaraswamy, P. (1980). A generalized probability density function for double-bounded random processes.
 Journal of Hydrology, 46(1), 79-88.
 
-Available at : \url{http://dx.doi.org/10.1016/0022-1694(80)90036-0}.
+Available at : \url{https://doi.org/10.1016/0022-1694(80)90036-0}.
 
 Jones, M. C. (2009). Kumaraswamy's distribution: A beta-type distribution with some tractability advantages.
 Statistical Methodology, 6(1), 70-81.
 
-Available at : \url{http://dx.doi.org/10.1016/j.stamet.2008.04.001}.
+Available at : \url{https://doi.org/10.1016/j.stamet.2008.04.001}.
 }
 \seealso{
 \code{\link[extraDistr]{Kumaraswamy}}

--- a/man/mazTRI.Rd
+++ b/man/mazTRI.Rd
@@ -85,7 +85,7 @@ Wiley Series in Probability and Mathematical Statistics, Wiley.
 Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.
 
-Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2}.
+Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2}.
 
 Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics

--- a/man/pGHGBB.Rd
+++ b/man/pGHGBB.Rd
@@ -84,7 +84,7 @@ pGHGBB(0:7,7,1.3,0.3,1.3)     #acquiring the cumulative probability values
 Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 
-Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}
+Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}
 
 Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 }

--- a/man/pGHGBeta.Rd
+++ b/man/pGHGBeta.Rd
@@ -90,7 +90,7 @@ mazGHGBeta(1.9,15,5,6,1)
 Rodriguez-Avi, J., Conde-Sanchez, A., Saez-Castillo, A. J., & Olmo-Jimenez, M. J. (2007). A generalization
 of the beta-binomial distribution. Journal of the Royal Statistical Society. Series C (Applied Statistics), 56(1), 51-61.
 
-Available at : \url{http://dx.doi.org/10.1111/j.1467-9876.2007.00564.x}
+Available at : \url{https://doi.org/10.1111/j.1467-9876.2007.00564.x}
 
 Pearson, J., 2009. Computation of Hypergeometric Functions. Transformation, (September), p.1--123.
 }

--- a/man/pKUM.Rd
+++ b/man/pKUM.Rd
@@ -80,12 +80,12 @@ mazKUM(1.9,5.5,6)
 Kumaraswamy, P. (1980). A generalized probability density function for double-bounded random processes.
 Journal of Hydrology, 46(1), 79-88.
 
-Available at : \url{http://dx.doi.org/10.1016/0022-1694(80)90036-0}.
+Available at : \url{https://doi.org/10.1016/0022-1694(80)90036-0}.
 
 Jones, M. C. (2009). Kumaraswamy's distribution: A beta-type distribution with some tractability advantages.
 Statistical Methodology, 6(1), 70-81.
 
-Available at : \url{http://dx.doi.org/10.1016/j.stamet.2008.04.001}.
+Available at : \url{https://doi.org/10.1016/j.stamet.2008.04.001}.
 }
 \seealso{
 \code{\link[extraDistr]{Kumaraswamy}}

--- a/man/pTRI.Rd
+++ b/man/pTRI.Rd
@@ -85,7 +85,7 @@ Wiley Series in Probability and Mathematical Statistics, Wiley.
 Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.
 
-Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2} .
+Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2} .
 
 Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics

--- a/man/pTriBin.Rd
+++ b/man/pTriBin.Rd
@@ -81,7 +81,7 @@ Series A, 120:148-191.
 Karlis, D. & Xekalaki, E., 2008. The Polygonal Distribution. In Advances in Mathematical and Statistical
 Modeling. Boston: Birkhuser Boston, pp. 21-33.
 
-Available at: \url{http://dx.doi.org/10.1007/978-0-8176-4626-4_2}.
+Available at: \url{https://doi.org/10.1007/978-0-8176-4626-4_2}.
 
 Okagbue, H. et al., 2014. Using the Average of the Extreme Values of a Triangular Distribution for a
 Transformation, and Its Approximant via the Continuous Uniform Distribution. British Journal of Mathematics


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!